### PR TITLE
add option to force generation tile generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ dyn:
     # Optional:
     mingen: 10  # Only generate tiles if missing within this zoom range
     maxgen: 18
-    minstore: 10  # if generated, only store them if within this zoom range 
+    minstore: 10  # if generated, only store them if within this zoom range
     maxstore: 15
+    forcegen: false # enable to force tile generation
 ```
 
 See https://github.com/kartotherian/kartotherian

--- a/autogen.js
+++ b/autogen.js
@@ -9,6 +9,8 @@ function Autogen(uri, callback) {
     var query;
     BBPromise.try(function () {
         query = core.normalizeUri(uri).query;
+        core.checkType(query, 'forcegen', 'boolean');
+        self.forcegen = !!query.forcegen;
         core.checkType(query, 'mingen', 'zoom');
         self.mingen = query.mingen;
         core.checkType(query, 'maxgen', 'zoom');
@@ -30,8 +32,12 @@ function Autogen(uri, callback) {
 
 Autogen.prototype.getTile = function(z, x, y, callback) {
     var self = this;
-    return self.storage
-        .getTileAsync(z, x, y)
+
+    var getp = self.forcegen
+      ? attempt(() => core.throwNoTile())
+      : self.storage.getTileAsync(z, x, y)
+
+    return getp
         .catch(function (err) {
             if ((self.mingen !== undefined && z < self.mingen) ||
                 (self.maxgen !== undefined && z > self.maxgen) ||


### PR DESCRIPTION
I may be missing something, still getting familiar around here...

This adds a `forcegen` option to the `autogen` source, so that services like tilerator can forcefully populate the cache.

``` yaml
autogenpbf:
  formats: [pbf]
  uri: autogen://
  params:
    storage: {ref: pbfstore}
    generator: {ref: pbfgen}
    forcegen: true
```

(Is there a better way to do this?)
